### PR TITLE
Add support for Go 1.20 errors.Join

### DIFF
--- a/_example/main.go
+++ b/_example/main.go
@@ -27,10 +27,23 @@ func bar() error {
 	return errors.WithStack(withErr)
 }
 
+func baz() error {
+	withErr := errors.With(foo(), errors.New("Yet another bad thing happened"))
+	return errors.WithStack(withErr)
+}
+
 func main() {
 	myErr := bar()
 	fmt.Println("Doing something")
 	err := errors.WithStack(myErr)
-	fmt.Println("----")
+
+	myOtherErr := errors.WithStack(baz())
+
+	joinErr := errors.Join(err, myOtherErr)
+	fmt.Println("\n\n---withStackBar")
 	fmt.Printf("%+v\n", err)
+	fmt.Println("\n\n---baz")
+	fmt.Printf("%+v\n", myOtherErr)
+	fmt.Println("\n\n---joinErr")
+	fmt.Printf("%+v\n", joinErr)
 }

--- a/errors/join.go
+++ b/errors/join.go
@@ -2,6 +2,7 @@ package errors
 
 import (
 	"fmt"
+	"strings"
 )
 
 // Join returns an error that wraps the given errors.
@@ -55,7 +56,9 @@ func (e *joinError) Format(w fmt.State, verb rune) {
 		if i > 0 {
 			fmt.Fprint(w, "\n")
 		}
-		fmt.Fprintf(w, "[%d]:\n", i)
-		fmt.Fprintf(w, fmt.FormatString(w, verb), err)
+		fmt.Fprintf(w, "[%d]: %s\n  ", i, err.Error())
+		s := fmt.Sprintf(fmt.FormatString(w, verb), err)
+		s = strings.Join(strings.Split(s, "\n"), "\n  ")
+		fmt.Fprint(w, s)
 	}
 }

--- a/errors/join.go
+++ b/errors/join.go
@@ -1,0 +1,61 @@
+package errors
+
+import (
+	"fmt"
+)
+
+// Join returns an error that wraps the given errors.
+// Any nil error values are discarded.
+// Join returns nil if errs contains no non-nil values.
+// The error formats as the concatenation of the strings obtained
+// by calling the Error method of each element of errs, with a newline
+// between each string.
+func Join(errs ...error) error {
+	n := 0
+	for _, err := range errs {
+		if err != nil {
+			n++
+		}
+	}
+	if n == 0 {
+		return nil
+	}
+	e := &joinError{
+		errs: make([]error, 0, n),
+	}
+	for _, err := range errs {
+		if err != nil {
+			e.errs = append(e.errs, err)
+		}
+	}
+	return e
+}
+
+type joinError struct {
+	errs []error
+}
+
+func (e *joinError) Error() string {
+	var b []byte
+	for i, err := range e.errs {
+		if i > 0 {
+			b = append(b, '\n')
+		}
+		b = append(b, err.Error()...)
+	}
+	return string(b)
+}
+
+func (e *joinError) Unwrap() []error {
+	return e.errs
+}
+
+func (e *joinError) Format(w fmt.State, verb rune) {
+	for i, err := range e.Unwrap() {
+		if i > 0 {
+			fmt.Fprint(w, "\n")
+		}
+		fmt.Fprintf(w, "[%d]:\n", i)
+		fmt.Fprintf(w, fmt.FormatString(w, verb), err)
+	}
+}

--- a/errors/stderrors.go
+++ b/errors/stderrors.go
@@ -33,7 +33,7 @@ func Unwrap(err error) error { return UnwrapOnce(err) }
 // As finds the first error in err's chain that matches the type to which
 // target points, and if so, sets the target to its value and returns true.
 // An error matches a type if it is assignable to the target type, or if it
-// has a method As(interface{}) bool such that As(target) returns true. As
+// has a method As(any) bool such that As(target) returns true. As
 // will panic if target is not a non-nil pointer to a type which implements
 // error or is of interface type.
 //
@@ -47,7 +47,7 @@ func Unwrap(err error) error { return UnwrapOnce(err) }
 // As finds the first error in err's chain that matches the type to which
 // target points, and if so, sets the target to its value and returns true.
 // An error matches a type if it is assignable to the target type, or if it
-// has a method As(interface{}) bool such that As(target) returns true. As
+// has a method As(any) bool such that As(target) returns true. As
 // will panic if target is not a non-nil pointer to a type which implements
 // error or is of interface type.
 //
@@ -57,7 +57,7 @@ func Unwrap(err error) error { return UnwrapOnce(err) }
 // Note: this implementation differs from that of xerrors as follows:
 // - it also supports recursing through causes with Cause().
 // - if it detects an API use error, its panic object is a valid error.
-func As(err error, target interface{}) bool {
+func As(err error, target any) bool {
 	if target == nil {
 		panic(fmt.Errorf("errors.As: target cannot be nil"))
 	}
@@ -80,7 +80,7 @@ func As(err error, target interface{}) bool {
 
 			return true
 		}
-		if x, ok := c.(interface{ As(interface{}) bool }); ok && x.As(target) {
+		if x, ok := c.(interface{ As(any) bool }); ok && x.As(target) {
 			return true
 		}
 	}
@@ -152,7 +152,7 @@ func Is(err, reference error) bool {
 }
 
 // This is only extracted to make the linters not suggest fixing it
-func equal(err, reference interface{}) bool {
+func equal(err, reference any) bool {
 	return err == reference
 }
 

--- a/errors/unwrap.go
+++ b/errors/unwrap.go
@@ -19,6 +19,11 @@ func UnwrapOnce(err error) (cause error) {
 		return e.Cause()
 	case interface{ Unwrap() error }:
 		return e.Unwrap()
+	case interface{ Unwrap() []error }:
+		errs := e.Unwrap()
+		if len(errs) > 0 {
+			return errs[0]
+		}
 	}
 
 	return nil

--- a/errors/unwrap.go
+++ b/errors/unwrap.go
@@ -14,6 +14,9 @@ package errors
 // github.com/pkg/errors) and `Wrapper` (`Unwrap()` method, from the
 // Go 2 error proposal).
 func UnwrapOnce(err error) (cause error) {
+	if err == nil {
+		return nil
+	}
 	switch e := err.(type) {
 	case interface{ Cause() error }:
 		return e.Cause()

--- a/errors/with.go
+++ b/errors/with.go
@@ -69,7 +69,7 @@ func (s *wrapper) Is(target error) bool {
 
 // As implements the interface needed for errors.As. It checks s.front first, and
 // then s.back.
-func (s *wrapper) As(target interface{}) bool {
+func (s *wrapper) As(target any) bool {
 	// This code copied exactly from errors.As, minus the code to unwrap if the
 	// check fails. Thus, it is effectively like calling errors.As(s.front,
 	// target).
@@ -93,7 +93,7 @@ func (s *wrapper) As(target interface{}) bool {
 		val.Elem().Set(reflectlite.ValueOf(s.front))
 		return true
 	}
-	if x, ok := s.front.(interface{ As(interface{}) bool }); ok && x.As(target) {
+	if x, ok := s.front.(interface{ As(any) bool }); ok && x.As(target) {
 		return true
 	}
 	for inner := s.Unwrap(); inner != nil; inner = UnwrapOnce(inner) {

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/StevenACoffman/simplerr
 
-go 1.19
+go 1.20

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/StevenACoffman/simplerr
 
-go 1.16
+go 1.19


### PR DESCRIPTION
Go 1.20 adds `errors.Join`

All errors produced using this library that are combined using Go 1.20 std lib `errors.Join` will lose the stacktrace when you `fmt.Printf("%+v\n", err)` on the joined error. Also, without native `errors.Join` support, this library would not a drop in replacement for the Go 1.20 stdlib `errors` package.

This PR adds `errors.Join` from Go 1.20 stdlib, but with a `Format()` method so joined errors honor the format verbs. Joined errors are printed verbosely indexed in square brackets like `[0]`, to differentiate them from the parenthetical indexing `(0)` of wrapped errors.

```
[0]: Another bad thing happened: Something went wrong
  (1) Another bad thing happened: Something went wrong
    -- Stack trace:
    | [...repeated from below...]
  Wraps: (2) Another bad thing happened: Something went wrong
  Wraps: (3) Something went wrong
    -- Stack trace:main.foo
    | 	./main.go:22
    | main.bar
    | 	./main.go:26
    | main.main
    | 	./main.go:36
    | runtime.main
    | 	runtime/proc.go:250
  Wraps: (4) Something went wrong
  Error types: (1) *errors.withStack (2) *errors.wrapper (3) *errors.withStack (4) main.ErrMyError
    -- Stack trace:main.main
    | 	./main.go:38
[1]: Yet another bad thing happened: Something went wrong
  (1) Yet another bad thing happened: Something went wrong
    -- Stack trace:
    | [...repeated from below...]
  Wraps: (2) Yet another bad thing happened: Something went wrong
  Wraps: (3) Something went wrong
    -- Stack trace:main.foo
    | 	./main.go:22
    | main.baz
    | 	./main.go:31
    | main.main
    | 	./main.go:40
    | runtime.main
    | 	runtime/proc.go:250
  Wraps: (4) Something went wrong
  Error types: (1) *errors.withStack (2) *errors.wrapper (3) *errors.withStack (4) main.ErrMyError
    -- Stack trace:main.main
    | 	./main.go:40
```

Signed-off-by: Steve Coffman <steve@khanacademy.org>
